### PR TITLE
Explicit project subject count

### DIFF
--- a/models/project.js
+++ b/models/project.js
@@ -82,6 +82,8 @@
 
     Project.prototype.user_count = 0;
 
+    Project.prototype.subject_count = 0;
+
     Project.prototype.display_name = '';
 
     Project.prototype.name = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zooniverse",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "devDependencies": {
     "chai": "~1.9.1",
     "chai-jquery": "~1.2.1",

--- a/src/models/project.coffee
+++ b/src/models/project.coffee
@@ -58,6 +58,7 @@ class Project extends BaseModel
   classification_count: 0
   complete_count: 0
   user_count: 0
+  subject_count: 0
 
   display_name: ''
   name: ''


### PR DESCRIPTION
This change just makes Project.subject_count an explicit variable so is mainly for readability (it would bind anyway if sent from API call)    However, only accept this if a back-end change to Ouroboros to set subject_count also goes through.  

Currently, this field is rarely sent from API call /projects/$PROJECT_NAME.  However, Panoptes will most likely send it.   After some discussion with @edpaget, we decided this was probably a reasonable de-normalization to have on Ouroboros.  Projects that needed to have comprehensive stats on the front end would otherwise have to make multiple fetches on Groups. 
