### PR TITLE
Fixes behavior referenced in #38

### DIFF
--- a/models/base-model.js
+++ b/models/base-model.js
@@ -93,6 +93,7 @@
       }
       BaseModel.__super__.constructor.apply(this, arguments);
       for (property in params) {
+        if (!__hasProp.call(params, property)) continue;
         value = params[property];
         this[property] = value;
       }

--- a/src/models/base-model.coffee
+++ b/src/models/base-model.coffee
@@ -38,7 +38,7 @@ class BaseModel extends EventEmitter
 
   constructor: (params = {}) ->
     super
-    @[property] = value for property, value of params
+    @[property] = value for own property, value of params
 
     @constructor.idCounter += 1
     @id = "C_#{@constructor.idCounter}" unless @id?


### PR DESCRIPTION
My brain starts to go in circles when I keep looking at this, so I might say something horribly incorrect here.

But what it looks like to me is that 14ad24a9cbd2dbb22ae9c90e8ae105dfe47cab25 caused the issue. When a new SubjectForRecent was created, it iterated over all properties, including the Subject constructor. So when it got to the point of adding the instances to the instances array, the object was actually a Subject.

This partially reverts the change, but allows the params set to be flexible. So the "selected_light_curve" property needed for PH still is fine.
